### PR TITLE
fix: add missing context to ci action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,4 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: daklon/webserver:latest
+          context: ./challenge-1/


### PR DESCRIPTION
the build and push step was missing the required parameter to define the context, therefore it was not pushing the image